### PR TITLE
fix cache freezes

### DIFF
--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -15,7 +15,6 @@ RUN { \
 		echo 'opcache.memory_consumption=128'; \
 		echo 'opcache.interned_strings_buffer=8'; \
 		echo 'opcache.max_accelerated_files=4000'; \
-		echo 'opcache.revalidate_freq=60'; \
 		echo 'opcache.fast_shutdown=1'; \
 		echo 'opcache.enable_cli=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -13,7 +13,6 @@ RUN { \
 		echo 'opcache.memory_consumption=128'; \
 		echo 'opcache.interned_strings_buffer=8'; \
 		echo 'opcache.max_accelerated_files=4000'; \
-		echo 'opcache.revalidate_freq=60'; \
 		echo 'opcache.fast_shutdown=1'; \
 		echo 'opcache.enable_cli=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini


### PR DESCRIPTION
Hello everyone.
Our company is using MODX as a daily driver and recently we wrapped our infrastructure into docker containers.
Everything was well enough until we started to notice a delay between making changes to the snippet with disabled cache and the actual result on the web page.
Lags were not persistent and could or could not happen. But when this lag eventually appears it lasts for around 60 seconds and only then snippet change is finally applied to web page.
All MODX instances that were not converted to docker containers did not have this lag.
After some research the key difference was found: by default non-dockerized MODX instances were using default `opcache.revalidate_freq` parameter (that equals to 2), meanwhile all new dockerized instances were using a php image with `opcache.revalidate_freq=60`.
After removing this instruction from php Dockerfile the issue with lag was solved.